### PR TITLE
[feat] 엔티티 연관관계 수정

### DIFF
--- a/src/main/java/com/encore/logeat/follow/domain/Follow.java
+++ b/src/main/java/com/encore/logeat/follow/domain/Follow.java
@@ -1,13 +1,17 @@
 package com.encore.logeat.follow.domain;
 
 
+import com.encore.logeat.user.domain.User;
 import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 @Entity
 public class Follow {
@@ -17,8 +21,11 @@ public class Follow {
 	private Long id;
 
 
-	private Long follow; // -> 내가 팔로우 하는 사람
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "follow_id")
+	private User follower;
 
-	@Column(name = "follow_to_me")
-	private Long followToMe; // -> 나를 팔로우 하는 사람
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "following_id")
+	private User following;
 }

--- a/src/main/java/com/encore/logeat/like/domain/Like.java
+++ b/src/main/java/com/encore/logeat/like/domain/Like.java
@@ -8,6 +8,8 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
@@ -17,13 +19,12 @@ public class Like {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-
-	private int count;
-
-	@OneToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "post_id", nullable = false)
 	private Post post;
 
-	@OneToMany(fetch = FetchType.LAZY)
-	private List<User> userList;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
 
 }

--- a/src/main/java/com/encore/logeat/post/domain/Post.java
+++ b/src/main/java/com/encore/logeat/post/domain/Post.java
@@ -3,6 +3,7 @@ package com.encore.logeat.post.domain;
 import com.encore.logeat.common.entity.BaseTimeEntity;
 import com.encore.logeat.like.domain.Like;
 import com.encore.logeat.user.domain.User;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -13,6 +14,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
+import javax.persistence.Table;
 
 @Entity
 public class Post extends BaseTimeEntity {
@@ -36,8 +38,7 @@ public class Post extends BaseTimeEntity {
 	@JoinColumn(name = "user_id")
 	private User user;
 
-	@OneToOne(mappedBy = "post", fetch = FetchType.LAZY)
-	@JoinColumn(name = "like_id")
-	private Like like;
+	@OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
+	private List<Like> likes_list;
 
 }

--- a/src/main/java/com/encore/logeat/user/domain/User.java
+++ b/src/main/java/com/encore/logeat/user/domain/User.java
@@ -14,7 +14,6 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -48,8 +47,10 @@ public class User extends BaseTimeEntity {
 	@OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
 	private List<Post> postList;
 
-	@OneToMany(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id")
-	private List<Follow> follow;
+	@OneToMany(mappedBy = "following",fetch = FetchType.LAZY)
+	private List<Follow> followerList; // 유저를 팔로우
+
+	@OneToMany(mappedBy = "follower",fetch = FetchType.LAZY)
+	private List<Follow> followingList; // 유저가 팔로우
 
 }


### PR DESCRIPTION
feat: 엔티티 연관 관계 수정

1. 'Follow' 테이블의 연관 관계 수정
   - 'Follow' 테이블은 팔로워(follower)와 팔로잉(following)의 두 사용자 객체 간의 관계를 나타냅니다.
   - 예를 들어, A가 B를 팔로우하는 경우 A의 'following' 리스트에 Follow(follower: A, following: B) 형식으로 추가되어야 합니다.
     동시에 B의 'follower' 리스트에 Follow(follower: A, following: B) 형식으로 추가되어야 합니다.

2. 'LIKE' 테이블의 연관 관계 수정
   - 'LIKE' 테이블은 user_id(좋아요를 누른 사용자)와 post_id(좋아요가 눌러진 글)로 구성됩니다.
   - 'Post' 테이블은 이제 LIKE 객체의 리스트를 포함해야 합니다.