### PR TITLE
[feat] JWT Filter 구현

### DIFF
--- a/src/main/java/com/encore/logeat/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/encore/logeat/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,59 @@
+package com.encore.logeat.common.jwt;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Autowired
+	public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+		this.jwtTokenProvider = jwtTokenProvider;
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		String token = parseBearerToken(request);
+		User user = parseUserSpecification(token);
+		UsernamePasswordAuthenticationToken authenticated = UsernamePasswordAuthenticationToken.authenticated(
+			user, token, user.getAuthorities());
+		authenticated.setDetails(new WebAuthenticationDetails(request));
+		SecurityContextHolder.getContext().setAuthentication(authenticated);
+
+		filterChain.doFilter(request, response);
+	}
+
+	private String parseBearerToken(HttpServletRequest request) {
+		return Optional.ofNullable(request.getHeader(HttpHeaders.AUTHORIZATION))
+			.filter(token -> token.substring(0, 7).equalsIgnoreCase("Bearer "))
+			.map(token -> token.substring(7))
+			.orElse(null);
+	}
+
+	private User parseUserSpecification(String token) {
+		String[] split = Optional.ofNullable(token)
+			.filter(subject -> subject.length() >= 10)
+			.map(jwtTokenProvider::validateTokenAndGetSubject)
+			.orElse("anonymous:anonymous")
+			.split(":");
+
+		return new User(split[0], "", List.of(new SimpleGrantedAuthority(split[1])));
+	}
+}

--- a/src/main/java/com/encore/logeat/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/encore/logeat/common/jwt/JwtTokenProvider.java
@@ -7,7 +7,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
-import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Service;
@@ -30,11 +29,19 @@ public class JwtTokenProvider {
 	public String createToken(String userSpecification) {
 
 		return Jwts.builder()
-			.signWith(SignatureAlgorithm.HS256, secretKey)
+			.signWith(SignatureAlgorithm.HS256, secretKey.getBytes())
 			.setSubject(userSpecification)
 			.setIssuer(issuer)
 			.setIssuedAt(Timestamp.valueOf(LocalDateTime.now()))
 			.setExpiration(Date.from(Instant.now().plus(expirationHours, ChronoUnit.HOURS)))
 			.compact();
+	}
+
+	public String validateTokenAndGetSubject(String token) {
+		return Jwts.parser()
+			.setSigningKey(secretKey.getBytes())
+			.parseClaimsJws(token)
+			.getBody()
+			.getSubject();
 	}
 }

--- a/src/main/java/com/encore/logeat/common/security/SecurityConfig.java
+++ b/src/main/java/com/encore/logeat/common/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.encore.logeat.common.security;
 
+import com.encore.logeat.common.jwt.JwtAuthenticationFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,12 +11,19 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
 @EnableWebSecurity
 @EnableMethodSecurity(prePostEnabled = true)
 @Configuration
 public class SecurityConfig {
+
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+	@Autowired
+	public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+		this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+	}
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
@@ -23,11 +31,12 @@ public class SecurityConfig {
 			.cors(cors -> cors.disable())
 			.httpBasic(basic -> basic.disable())
 			.authorizeHttpRequests(req -> req
-				.antMatchers("/user/new", "/doLogin")
+				.antMatchers()
 				.permitAll()
 				.anyRequest().authenticated())
 			.sessionManagement(session -> session
-				.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.addFilterBefore(jwtAuthenticationFilter, BasicAuthenticationFilter.class);
 
 		return httpSecurity.build();
 	}

--- a/src/main/java/com/encore/logeat/follow/domain/Follow.java
+++ b/src/main/java/com/encore/logeat/follow/domain/Follow.java
@@ -2,8 +2,6 @@ package com.encore.logeat.follow.domain;
 
 
 import com.encore.logeat.user.domain.User;
-import java.util.List;
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -11,7 +9,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.Table;
 
 @Entity
 public class Follow {
@@ -19,7 +16,6 @@ public class Follow {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "follow_id")

--- a/src/main/java/com/encore/logeat/user/controller/UserController.java
+++ b/src/main/java/com/encore/logeat/user/controller/UserController.java
@@ -35,7 +35,5 @@ public class UserController {
 		@RequestBody UserLoginRequestDto userLoginRequestDto) {
 		ResponseDto responseDto = userService.userLogin(userLoginRequestDto);
 		return new ResponseEntity<>(responseDto, HttpStatus.OK);
-
-
 	}
 }

--- a/src/main/java/com/encore/logeat/user/service/UserService.java
+++ b/src/main/java/com/encore/logeat/user/service/UserService.java
@@ -30,7 +30,8 @@ public class UserService {
 
 	@Transactional
 	public User createUser(UserCreateRequestDto userCreateRequestDto) {
-		userCreateRequestDto.setPassword(passwordEncoder.encode(userCreateRequestDto.getPassword()));
+		userCreateRequestDto.setPassword(
+			passwordEncoder.encode(userCreateRequestDto.getPassword()));
 		User user = userCreateRequestDto.toEntity();
 		// 유저 프로필 이미지 추가해주는 로직 작성 필요
 		return userRepository.save(user);
@@ -39,7 +40,9 @@ public class UserService {
 	@Transactional
 	public ResponseDto userLogin(UserLoginRequestDto userLoginRequestDto) {
 		User user = userRepository.findByEmail(userLoginRequestDto.getEmail())
-			.orElseThrow(() -> new EntityNotFoundException("가입되지 않은 이메일 주소입니다."));
+			.filter(
+				it -> passwordEncoder.matches(userLoginRequestDto.getPassword(), it.getPassword()))
+			.orElseThrow(() -> new IllegalArgumentException("이메일 또는 비밀번호가 일치하지 않습니다."));
 		String token = jwtTokenProvider.createToken(
 			String.format("%s:%s", user.getId(), user.getRole()));
 		return new ResponseDto(HttpStatus.OK, "JWT token is created!", token);


### PR DESCRIPTION
feat: JwtAuthenticationFilter 구현

1. JwtAuthenticationFilter
   - doFilterInternal: HttpServletRequest의 헤더의 Authorization 부분을 읽어와 토큰을 가져온 후, 토큰의 정보로 User의 Id와 Role을 추출하여,
     Spring SecurityContextHolder에 유저 정보를 사용하여 만든 Authentication 객체를 저장합니다.
   - parseBearerToken: HttpServletRequest에서 토큰 정보를 추출하는 메서드입니다.
   - parseUserSpecification: 토큰에 "{userId}:{userRole}" 형태로 저장된 정보를 읽어와 유저 객체를 생성하는 메서드입니다.

2. JwtTokenProvider
   - validateTokenAndGetSubject: 토큰에 담긴 Subject를 해독하여, 토큰을 생성할 때 "{userId}:{userRole}" 형태로 저장된 정보를 가져옵니다.

3. SecurityConfig
   - addFilterBefore: BearerTokenAuthenticationFilter → BasicAuthenticationFilter로 이어지는 필터의 순서에
     BearerTokenAuthenticationFilter → JwtAuthenticationFilter → BasicAuthenticationFilter로
     JwtAuthenticationFilter를 삽입합니다.

4. UserService
   - login 메서드 실행 시 유저의 비밀번호 검증 기능이 추가되었습니다.

