### PR TITLE
유저 로그인시 Refresh Token 발급

### DIFF
--- a/src/main/java/com/encore/logeat/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/encore/logeat/common/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.encore.logeat.common.jwt;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
@@ -9,11 +10,11 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -30,21 +31,47 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
-		String token = parseBearerToken(request);
-		User user = parseUserSpecification(token);
-		UsernamePasswordAuthenticationToken authenticated = UsernamePasswordAuthenticationToken.authenticated(
-			user, token, user.getAuthorities());
-		authenticated.setDetails(new WebAuthenticationDetails(request));
-		SecurityContextHolder.getContext().setAuthentication(authenticated);
+		try {
+			String token = parseBearerToken(request, HttpHeaders.AUTHORIZATION);
+			User user = parseUserSpecification(token);
+			UsernamePasswordAuthenticationToken authenticated = UsernamePasswordAuthenticationToken.authenticated(
+				user, token, user.getAuthorities());
+			authenticated.setDetails(new WebAuthenticationDetails(request));
+			SecurityContextHolder.getContext().setAuthentication(authenticated);
+		} catch (ExpiredJwtException e) {
+			reissueAccessToken(request, response, e);
+		} catch (Exception e) {
+			request.setAttribute("exception" , e);
+		}
 
 		filterChain.doFilter(request, response);
 	}
 
-	private String parseBearerToken(HttpServletRequest request) {
-		return Optional.ofNullable(request.getHeader(HttpHeaders.AUTHORIZATION))
+	private String parseBearerToken(HttpServletRequest request, String headerName) {
+		return Optional.ofNullable(request.getHeader(headerName))
 			.filter(token -> token.substring(0, 7).equalsIgnoreCase("Bearer "))
 			.map(token -> token.substring(7))
 			.orElse(null);
+	}
+
+	private void reissueAccessToken(HttpServletRequest request, HttpServletResponse response, Exception exception) {
+		try {
+			String refreshToken = parseBearerToken(request, "Refresh-Token");
+			if (refreshToken == null) {
+				throw exception;
+			}
+			String oldAccessToken = parseBearerToken(request, HttpHeaders.AUTHORIZATION);
+			jwtTokenProvider.validateRefreshToken(refreshToken, oldAccessToken);
+			String newAccessToken = jwtTokenProvider.recreateAccessToken(oldAccessToken);
+			User user = parseUserSpecification(newAccessToken);
+			AbstractAuthenticationToken authenticated = UsernamePasswordAuthenticationToken.authenticated(user, newAccessToken, user.getAuthorities());
+			authenticated.setDetails(new WebAuthenticationDetails(request));
+			SecurityContextHolder.getContext().setAuthentication(authenticated);
+
+			response.setHeader("New-Access-Token", newAccessToken);
+		} catch (Exception e) {
+			request.setAttribute("exception", e);
+		}
 	}
 
 	private User parseUserSpecification(String token) {

--- a/src/main/java/com/encore/logeat/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/encore/logeat/common/jwt/JwtTokenProvider.java
@@ -1,5 +1,7 @@
 package com.encore.logeat.common.jwt;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.sql.Timestamp;
@@ -38,10 +40,11 @@ public class JwtTokenProvider {
 	}
 
 	public String validateTokenAndGetSubject(String token) {
-		return Jwts.parser()
-			.setSigningKey(secretKey.getBytes())
-			.parseClaimsJws(token)
-			.getBody()
-			.getSubject();
+		Jws<Claims> claimsJws = Jwts.parser().setSigningKey(secretKey.getBytes())
+			.parseClaimsJws(token);
+		if(!claimsJws.getBody().getExpiration().before(new Date())) {
+			return claimsJws.getBody().getSubject();
+		}
+		return null;
 	}
 }

--- a/src/main/java/com/encore/logeat/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/encore/logeat/common/jwt/JwtTokenProvider.java
@@ -28,7 +28,7 @@ public class JwtTokenProvider {
 		this.issuer = issuer;
 	}
 
-	public String createToken(String userSpecification) {
+	public String createAcessToken(String userSpecification) {
 
 		return Jwts.builder()
 			.signWith(SignatureAlgorithm.HS256, secretKey.getBytes())

--- a/src/main/java/com/encore/logeat/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/encore/logeat/common/jwt/JwtTokenProvider.java
@@ -1,14 +1,24 @@
 package com.encore.logeat.common.jwt;
 
+import com.encore.logeat.common.jwt.refresh.UserRefreshToken;
+import com.encore.logeat.common.jwt.refresh.UserRefreshTokenRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Base64;
 import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+import javax.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Service;
@@ -18,33 +28,85 @@ import org.springframework.stereotype.Service;
 public class JwtTokenProvider {
 
 	private final String secretKey;
-	private final long expirationHours;
+	private final long expirationMinutes;
+	private final long refreshExpirationHours;
 	private final String issuer;
+	private final UserRefreshTokenRepository userRefreshTokenRepository;
+	private final long reissueLimit;
+	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	public JwtTokenProvider(@Value("${secret-key}") String secretKey,
-		@Value("${expiration-hours}") long expirationHours, @Value("${issuer}") String issuer) {
+		@Value("${expiration-minutes}") long expirationMinutes,
+		@Value("${refresh-expiration-hours}") long refreshExpirationHours,
+		@Value("${issuer}") String issuer, UserRefreshTokenRepository userRefreshTokenRepository) {
 		this.secretKey = secretKey;
-		this.expirationHours = expirationHours;
+		this.expirationMinutes = expirationMinutes;
+		this.refreshExpirationHours = refreshExpirationHours;
 		this.issuer = issuer;
+		this.userRefreshTokenRepository = userRefreshTokenRepository;
+		reissueLimit = refreshExpirationHours * 60 / expirationMinutes;
 	}
 
-	public String createAcessToken(String userSpecification) {
+	public String createAccessToken(String userSpecification) {
 
 		return Jwts.builder()
 			.signWith(SignatureAlgorithm.HS256, secretKey.getBytes())
 			.setSubject(userSpecification)
 			.setIssuer(issuer)
 			.setIssuedAt(Timestamp.valueOf(LocalDateTime.now()))
-			.setExpiration(Date.from(Instant.now().plus(expirationHours, ChronoUnit.HOURS)))
+			.setExpiration(Date.from(Instant.now().plus(expirationMinutes, ChronoUnit.MINUTES)))
 			.compact();
 	}
 
-	public String validateTokenAndGetSubject(String token) {
-		Jws<Claims> claimsJws = Jwts.parser().setSigningKey(secretKey.getBytes())
+	public String createRefreshToken() {
+
+		return Jwts.builder()
+			.signWith(SignatureAlgorithm.HS256, secretKey.getBytes())
+			.setIssuer(issuer)
+			.setIssuedAt(Timestamp.valueOf(LocalDateTime.now()))
+			.setExpiration(Date.from(Instant.now().plus(refreshExpirationHours, ChronoUnit.HOURS)))
+			.compact();
+	}
+
+	@Transactional
+	public String recreateAccessToken(String oldAccessToken) throws JsonProcessingException {
+		String subject = decodeJwtPayloadSubject(oldAccessToken);
+		userRefreshTokenRepository.findByUserIdAndReissueCountLessThan(
+			Long.parseLong(subject.split(":")[0]), reissueLimit)
+			.ifPresentOrElse(
+				UserRefreshToken::increaseReissueCount,
+				() -> {
+					throw new ExpiredJwtException(null, null, "Refresh token expried.");
+				}
+			);
+		return createAccessToken(subject);
+	}
+
+	@Transactional
+	public void validateRefreshToken(String refreshToken, String oldAccessToken) throws JsonProcessingException {
+		validateAndParseToken(refreshToken);
+		String memberId = decodeJwtPayloadSubject(oldAccessToken).split(":")[0];
+		userRefreshTokenRepository.findByUserIdAndReissueCountLessThan(Long.parseLong(memberId), reissueLimit)
+			.filter(memberRefreshToken -> memberRefreshToken.validateRefreshToken(refreshToken))
+			.orElseThrow(() -> new ExpiredJwtException(null, null, "Refresh token expired."));
+	}
+
+
+	private String decodeJwtPayloadSubject(String oldAccessToken) throws JsonProcessingException {
+		return objectMapper.readValue(
+			new String(Base64.getDecoder().decode(oldAccessToken.split("\\.")[1]),
+				StandardCharsets.UTF_8),
+			Map.class
+		).get("sub").toString();
+	}
+
+	private Jws<Claims> validateAndParseToken(String token) {	// validateTokenAndGetSubject에서 따로 분리
+		return Jwts.parser()
+			.setSigningKey(secretKey.getBytes())
 			.parseClaimsJws(token);
-		if(!claimsJws.getBody().getExpiration().before(new Date())) {
-			return claimsJws.getBody().getSubject();
-		}
-		return null;
+	}
+
+	public String validateTokenAndGetSubject(String token) {
+		return validateAndParseToken(token).getBody().getSubject();
 	}
 }

--- a/src/main/java/com/encore/logeat/common/jwt/refresh/UserRefreshToken.java
+++ b/src/main/java/com/encore/logeat/common/jwt/refresh/UserRefreshToken.java
@@ -1,0 +1,46 @@
+package com.encore.logeat.common.jwt.refresh;
+
+import com.encore.logeat.user.domain.User;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.MapsId;
+import javax.persistence.OneToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class UserRefreshToken {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	@OneToOne(fetch = FetchType.LAZY)
+	@MapsId
+	@JoinColumn(name = "user_id")
+	private User user;
+	private String refreshToken;
+	private int reissueCount = 0;
+
+	public UserRefreshToken(User user, String refreshToken) {
+		this.user = user;
+		this.refreshToken = refreshToken;
+	}
+
+	public void updateUserRefreshToken(String refreshToken) {
+		this.refreshToken = refreshToken;
+	}
+
+	public boolean validateRefreshToken(String refreshToken) {
+		return this.refreshToken.equals(refreshToken);
+	}
+
+	public void increaseReissueCount() {
+		this.reissueCount++;
+	}
+}

--- a/src/main/java/com/encore/logeat/common/jwt/refresh/UserRefreshTokenRepository.java
+++ b/src/main/java/com/encore/logeat/common/jwt/refresh/UserRefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.encore.logeat.common.jwt.refresh;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRefreshTokenRepository extends JpaRepository<UserRefreshToken, Long> {
+
+	Optional<UserRefreshToken> findByUserIdAndReissueCountLessThan(Long id, int count);
+
+}

--- a/src/main/java/com/encore/logeat/common/jwt/refresh/UserRefreshTokenRepository.java
+++ b/src/main/java/com/encore/logeat/common/jwt/refresh/UserRefreshTokenRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRefreshTokenRepository extends JpaRepository<UserRefreshToken, Long> {
 
-	Optional<UserRefreshToken> findByUserIdAndReissueCountLessThan(Long id, int count);
+	Optional<UserRefreshToken> findByUserIdAndReissueCountLessThan(Long id, long count);
 
 }

--- a/src/main/java/com/encore/logeat/post/Service/PostService.java
+++ b/src/main/java/com/encore/logeat/post/Service/PostService.java
@@ -3,6 +3,7 @@ package com.encore.logeat.post.Service;
 import com.encore.logeat.post.Dto.PostCreateRequestDto;
 import com.encore.logeat.post.domain.Post;
 import com.encore.logeat.post.repository.PostRepository;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -21,9 +22,10 @@ public class PostService {
     public PostService(PostRepository postRepository) {
         this.postRepository = postRepository;
     }
+    @PreAuthorize("hasAuthority('USER')")
     public Post createPost(PostCreateRequestDto postCreateRequestDto) {
-        MultipartFile multipartFile = postCreateRequestDto.getPostImage();
-        String fileName = multipartFile.getOriginalFilename();
+//        MultipartFile multipartFile = postCreateRequestDto.getPostImage();
+//        String fileName = multipartFile.getOriginalFilename();
         Post new_post = Post.builder()
                 .title(postCreateRequestDto.getTitle())
                 .contents(postCreateRequestDto.getContents())
@@ -32,14 +34,14 @@ public class PostService {
                 .build();
         Post post = postRepository.save(new_post);
 
-        Path path = Paths.get("/Users/jang-eunji/Desktop/tmp", post.getId() + "_" + fileName);
-        post.setImagePath(path.toString());
-        try {
-            byte[] bytes = multipartFile.getBytes();
-            Files.write(path, bytes, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
-        } catch (IOException e) {
-            throw new IllegalArgumentException("image not available");
-        }
+//        Path path = Paths.get("/Users/jang-eunji/Desktop/tmp", post.getId() + "_" + fileName);
+//        post.setImagePath(path.toString());
+//        try {
+//            byte[] bytes = multipartFile.getBytes();
+//            Files.write(path, bytes, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+//        } catch (IOException e) {
+//            throw new IllegalArgumentException("image not available");
+//        }
         return post;
     }
 

--- a/src/main/java/com/encore/logeat/user/service/UserService.java
+++ b/src/main/java/com/encore/logeat/user/service/UserService.java
@@ -43,7 +43,7 @@ public class UserService {
 			.filter(
 				it -> passwordEncoder.matches(userLoginRequestDto.getPassword(), it.getPassword()))
 			.orElseThrow(() -> new IllegalArgumentException("이메일 또는 비밀번호가 일치하지 않습니다."));
-		String token = jwtTokenProvider.createToken(
+		String token = jwtTokenProvider.createAcessToken(
 			String.format("%s:%s", user.getId(), user.getRole()));
 		return new ResponseDto(HttpStatus.OK, "JWT token is created!", token);
 	}


### PR DESCRIPTION
1. JwtAuthenticationFilter
- doFilterInternal: 원래의 필터는 HttpServletRequest의 Authorization 헤더에 담긴 JWT 토큰을 가져와 검증하고, 유효하지 않은 토큰인 경우 Exception을 발생시켰습니다. 변경된 필터는 이 로직을 try-catch 문으로 감싸 유효시간이 만료된 토큰인 경우 발생하는 ExpiredJwtException을 캐치하여, 유저의 Refresh 토큰을 검증하고 유효한 경우 새로운 AccessToken을 발급하는 로직으로 변경되었습니다.

- reissueAccessToken: AccessToken이 만료된 경우, 유저에게 전달한 Refresh Token을 받아옵니다. Refresh Token이 유효한 경우, 새로운 AccessToken을 발급하고, 이를 SecurityContextHolder에 유저 정보를 저장하며, 새로 발급된 AccessToken을 반환합니다.

2. JwtTokenProvider
- createRefreshToken: AccessToken과 달리 Subject에는 유저의 정보를 저장하지 않고 발급됩니다.
- recreateAccessToken: Access 토큰을 역직렬화하여 Subject에 저장된 유저의 정보를 가져와 재발급 횟수를 초과하지 않은 토큰을 찾아서, 재발급 횟수를 1 증가시키고, 새로운 AccessToken을 발급합니다.
- validateRefreshToken: 만료된 AccessToken을 받아 새로운 AccessToken을 발급하는 메서드로, 유저에게 받아온 Refresh Token을 검증한 뒤, 유효한 경우에는 Access Token의 유저 정보를 통해 유저와 1:1로 매치되는 UserRefreshToken 엔티티에 저장된 Refresh Token을 
가져와 유저가 제공한 Refresh Token과 같은지 검증합니다.
- decodeJwtPayloadSubject: Base64로 인코딩된 JWT의 Header와 Payload 부분을 디코딩하여 Payload의 sub (User의 정보가 저장된 부분)을 반환합니다.

3. UserRefreshToken
- 유저의 Refresh Token을 저장하는 테이블로 @MapsId 어노테이션은 OneToOne으로 매핑한 User의 정보를 FK 대신 PK로 사용하는 어노테이션입니다.

4. userLogin
- 유저가 로그인한 경우 Access Token과 Refresh Token을 생성합니다. 유저의 Refresh Token이 없는 경우 새로운 UserRefreshToken 객체를 생성하고, 이미 존재하는 경우에는 새로 발급한 Refresh Token으로 업데이트합니다. 이 정보는 Map 형식으로 Access Token과 Refresh Token을 반환합니다.
