### PR TITLE
게시글 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -32,6 +31,7 @@ dependencies {
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'logeat'
+rootProject.name = 'logEat'

--- a/src/main/java/com/encore/logeat/like/domain/Like.java
+++ b/src/main/java/com/encore/logeat/like/domain/Like.java
@@ -13,6 +13,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
+
 @Entity
 @Table(name = "likes")
 public class Like {

--- a/src/main/java/com/encore/logeat/post/Dto/RequestDto/PostCreateRequestDto.java
+++ b/src/main/java/com/encore/logeat/post/Dto/RequestDto/PostCreateRequestDto.java
@@ -9,7 +9,6 @@ import org.springframework.web.multipart.MultipartFile;
 @Builder
 @AllArgsConstructor
 public class PostCreateRequestDto {
-    private Long user_id;
     private String title;
     private String contents;
     private String category;

--- a/src/main/java/com/encore/logeat/post/Dto/RequestDto/PostUpdateRequestDto.java
+++ b/src/main/java/com/encore/logeat/post/Dto/RequestDto/PostUpdateRequestDto.java
@@ -8,7 +8,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Data
 @Builder
 @AllArgsConstructor
-public class PostCreateRequestDto {
+public class PostUpdateRequestDto {
     private Long user_id;
     private String title;
     private String contents;

--- a/src/main/java/com/encore/logeat/post/Dto/RequestDto/PostUpdateRequestDto.java
+++ b/src/main/java/com/encore/logeat/post/Dto/RequestDto/PostUpdateRequestDto.java
@@ -9,7 +9,6 @@ import org.springframework.web.multipart.MultipartFile;
 @Builder
 @AllArgsConstructor
 public class PostUpdateRequestDto {
-    private Long user_id;
     private String title;
     private String contents;
     private String category;

--- a/src/main/java/com/encore/logeat/post/Service/PostService.java
+++ b/src/main/java/com/encore/logeat/post/Service/PostService.java
@@ -72,7 +72,6 @@ public class PostService {
         String name = SecurityContextHolder.getContext().getAuthentication().getName();
         String[] split = name.split(":");
         long userId = Long.parseLong(split[0]);
-        System.out.println("userId = " + userId);
 
         if(userId == post.getUser().getId()){
             post.updatePost(

--- a/src/main/java/com/encore/logeat/post/Service/PostService.java
+++ b/src/main/java/com/encore/logeat/post/Service/PostService.java
@@ -1,34 +1,56 @@
 package com.encore.logeat.post.Service;
 
 import com.encore.logeat.post.Dto.RequestDto.PostCreateRequestDto;
+import com.encore.logeat.post.Dto.RequestDto.PostUpdateRequestDto;
 import com.encore.logeat.post.Dto.ResponseDto.PostSearchResponseDto;
 import com.encore.logeat.post.domain.Post;
 import com.encore.logeat.post.repository.PostRepository;
+import com.encore.logeat.user.domain.User;
+import com.encore.logeat.user.repository.UserRepository;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import javax.persistence.EntityNotFoundException;
 import javax.transaction.Transactional;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
 @Transactional
 public class PostService {
     private final PostRepository postRepository;
+    private final UserRepository userRepository;
 
-    public PostService(PostRepository postRepository) {
+    public PostService(PostRepository postRepository, UserRepository userRepository) {
         this.postRepository = postRepository;
+        this.userRepository = userRepository;
     }
     @PreAuthorize("hasAuthority('USER')")
     public Post createPost(PostCreateRequestDto postCreateRequestDto) {
 //        MultipartFile multipartFile = postCreateRequestDto.getPostImage();
 //        String fileName = multipartFile.getOriginalFilename();
+        String name = SecurityContextHolder.getContext().getAuthentication().getName();
+        String[] split = name.split(":");
+        long userId = Long.parseLong(split[0]);
+
+        User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException());
+
         Post new_post = Post.builder()
                 .title(postCreateRequestDto.getTitle())
                 .contents(postCreateRequestDto.getContents())
                 .category(postCreateRequestDto.getCategory())
                 .location(postCreateRequestDto.getLocation())
+                .user(user)
                 .build();
         Post post = postRepository.save(new_post);
 //        Path path = Paths.get("/Users/jang-eunji/Desktop/tmp", post.getId() + "_" + fileName);
@@ -41,7 +63,38 @@ public class PostService {
 //        }
         return post;
     }
+    @PreAuthorize("hasAuthority('USER')")
+    public Post update(Long id, PostUpdateRequestDto postUpdateRequestDto) {
+        Post post = postRepository.findById(id).orElseThrow(() -> new EntityNotFoundException("not found post"));
 
+//    MultipartFile multipartFile = postUpdateRequestDto.getPostImage();
+//    String fileName = multipartFile.getOriginalFilename();
+        String name = SecurityContextHolder.getContext().getAuthentication().getName();
+        String[] split = name.split(":");
+        long userId = Long.parseLong(split[0]);
+        System.out.println("userId = " + userId);
+
+        if(userId == post.getUser().getId()){
+            post.updatePost(
+                    postUpdateRequestDto.getTitle(),
+                    postUpdateRequestDto.getContents(),
+                    postUpdateRequestDto.getCategory(),
+                    postUpdateRequestDto.getLocation()
+//                ,postUpdateRequestDto.getPostImage()
+            );
+        }else {
+            // 업데이트 하는 유저 id랑 게시글 작성한 유저 id랑 다르면 어떤 에러 쓸지 몰라서 일단 RuntimeException갑니다.
+            throw new  RuntimeException("본인이 작성한 글만 수정 가능합니다.");
+        }
+//        Path path = Paths.get("/Users/jang-eunji/Desktop/tmp", post.getId()+"_"+fileName);
+//        try{
+//            byte[] bytes = multipartFile.getBytes();
+//            Files.write(path, bytes, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+//        } catch(IOException e){
+//            throw new IllegalArgumentException("image not available");
+//        }
+        return post;
+    }
     public List<PostSearchResponseDto> postTitleSearch(String titleKeyword) {
         List<Post> post = postRepository.findPostByTitleContaining(titleKeyword);
 
@@ -59,4 +112,5 @@ public class PostService {
         List<Post> post = postRepository.findByUserNickname(userNickname);
         return post.stream().map(PostSearchResponseDto::toPostSearchResponseDto).collect(Collectors.toList());
     }
+
 }

--- a/src/main/java/com/encore/logeat/post/controller/PostController.java
+++ b/src/main/java/com/encore/logeat/post/controller/PostController.java
@@ -2,6 +2,7 @@ package com.encore.logeat.post.controller;
 
 import com.encore.logeat.common.dto.ResponseDto;
 import com.encore.logeat.post.Dto.RequestDto.PostCreateRequestDto;
+import com.encore.logeat.post.Dto.RequestDto.PostUpdateRequestDto;
 import com.encore.logeat.post.Dto.ResponseDto.PostSearchResponseDto;
 import com.encore.logeat.post.Service.PostService;
 import com.encore.logeat.post.domain.Post;
@@ -27,6 +28,11 @@ public class PostController {
                 new ResponseDto(HttpStatus.CREATED, "new Post Created!", post.getId()),
                 HttpStatus.CREATED);
     }
+    @PatchMapping("/post/{id}/update")
+    public ResponseEntity<ResponseDto> itemUpdate(@PathVariable Long id, PostUpdateRequestDto postUpdateRequestDto){
+        Post post = postService.update(id, postUpdateRequestDto);
+        return new ResponseEntity<>(new ResponseDto(HttpStatus.OK, "post successfully updated", post.getId()), HttpStatus.OK);
+    }
 
     @GetMapping("/post/search/title")
     public List<PostSearchResponseDto> postIncludeTitleSearch(@RequestParam(value = "titleKeyword") String titleKeyword) {
@@ -45,4 +51,5 @@ public class PostController {
         List<PostSearchResponseDto> postSearchResponseDtoList = postService.postCategorySearch(category);
         return postSearchResponseDtoList;
     }
+
 }

--- a/src/main/java/com/encore/logeat/post/domain/Post.java
+++ b/src/main/java/com/encore/logeat/post/domain/Post.java
@@ -17,8 +17,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
 
 @Entity
 @Getter
@@ -51,4 +49,10 @@ public class Post extends BaseTimeEntity {
 	public void setImagePath(String imagePath){
 		this.imagePath = imagePath;
 	}
+	public void updatePost(String title, String contents, String location, String category){
+        this.title = title;
+        this.contents = contents;
+        this.location = location;
+        this.category = category;
+    }
 }


### PR DESCRIPTION
1. Controller 파일 수정
- PatchMapping을 추가하여 게시글 수정 기능을 구현
2. Service 파일 수정
- 게시글 수정 메소드에 게시글을 작성한 사용자 ID와 현재 로그인한 사용자 ID를 확인하는 로직을 추가
- 게시글 수정 시 게시글의 존재 여부를 확인하는 로직을 추가
- 게시글 작성 시 user_id가 DB에 추가되도록 수정하여, 게시글 작성 시에 사용자 ID가 함께 저장됨
3. Post 도메인 파일 수정
- 게시글 수정을 위한 메서드를 추가
4. RequestDto 폴더 수정
- 게시글 수정을 위한 RequestDto 파일을 추가
