### PR TITLE
[feat] 게시글 상세조회 캐싱 기능 구현

### DIFF
--- a/src/main/java/com/encore/logeat/LogeatApplication.java
+++ b/src/main/java/com/encore/logeat/LogeatApplication.java
@@ -2,8 +2,10 @@ package com.encore.logeat;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class LogeatApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/encore/logeat/common/redis/CacheNames.java
+++ b/src/main/java/com/encore/logeat/common/redis/CacheNames.java
@@ -6,9 +6,13 @@ import lombok.Getter;
 public class CacheNames {
 	public static final String POST = "post";
 	public static final String USER_PROFILE = "user_profile";
+	public static final String POST_CACHE = "postViewCnt";
 
 	public static String createPostCacheKey(Long id) {
 		return createCacheKey(POST, id);
+	}
+	public static String createViewCountCacheKey(Long id) {
+		return createCacheKey(POST_CACHE, id);
 	}
 
 	public static String createCacheKey(String cacheType, Long id) {

--- a/src/main/java/com/encore/logeat/common/redis/CacheNames.java
+++ b/src/main/java/com/encore/logeat/common/redis/CacheNames.java
@@ -1,0 +1,17 @@
+package com.encore.logeat.common.redis;
+
+import lombok.Getter;
+
+@Getter
+public class CacheNames {
+	public static final String POST = "post";
+	public static final String USER_PROFILE = "user_profile";
+
+	public static String createPostCacheKey(Long id) {
+		return createCacheKey(POST, id);
+	}
+
+	public static String createCacheKey(String cacheType, Long id) {
+		return cacheType + "::" + id;
+	}
+}

--- a/src/main/java/com/encore/logeat/common/redis/RedisConfig.java
+++ b/src/main/java/com/encore/logeat/common/redis/RedisConfig.java
@@ -1,15 +1,25 @@
 package com.encore.logeat.common.redis;
 
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.config.CacheNamespaceHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@EnableCaching
 public class RedisConfig {
     @Value("${spring.redis.host}")
     private String redisHost;
@@ -31,8 +41,6 @@ public class RedisConfig {
 
         return lettuceConnectionFactory;
     }
-
-
     @Bean
     public RedisTemplate<String, Object> redisTemplate() {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
@@ -43,5 +51,24 @@ public class RedisConfig {
         return redisTemplate;
     }
 
+    @Bean
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                new StringRedisSerializer()))
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                new GenericJackson2JsonRedisSerializer()));
+
+        Map<String, RedisCacheConfiguration> redisCacheConfigMap = new HashMap<>();
+        redisCacheConfigMap.put(CacheNames.POST, redisCacheConfiguration.entryTtl(
+            Duration.ofMinutes(3)));
+        redisCacheConfigMap.put(CacheNames.USER_PROFILE, redisCacheConfiguration.entryTtl(
+            Duration.ofDays(1)));
+        return RedisCacheManager.RedisCacheManagerBuilder
+            .fromConnectionFactory(redisConnectionFactory)
+            .cacheDefaults(redisCacheConfiguration)
+            .withInitialCacheConfigurations(redisCacheConfigMap)
+            .build();
+    }
 
 }

--- a/src/main/java/com/encore/logeat/common/redis/RedisConfig.java
+++ b/src/main/java/com/encore/logeat/common/redis/RedisConfig.java
@@ -61,7 +61,7 @@ public class RedisConfig {
 
         Map<String, RedisCacheConfiguration> redisCacheConfigMap = new HashMap<>();
         redisCacheConfigMap.put(CacheNames.POST, redisCacheConfiguration.entryTtl(
-            Duration.ofMinutes(3)));
+            Duration.ofMinutes(5)));
         redisCacheConfigMap.put(CacheNames.USER_PROFILE, redisCacheConfiguration.entryTtl(
             Duration.ofDays(1)));
         return RedisCacheManager.RedisCacheManagerBuilder

--- a/src/main/java/com/encore/logeat/common/redis/RedisService.java
+++ b/src/main/java/com/encore/logeat/common/redis/RedisService.java
@@ -1,5 +1,6 @@
 package com.encore.logeat.common.redis;
 
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -65,4 +66,12 @@ public class RedisService {
         return !value.equals("false");
     }
 
+    public void increment(String key) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        values.increment(key);
+    }
+
+    public Set<String> keys(String pattern) {
+        return redisTemplate.keys(pattern);
+    }
 }

--- a/src/main/java/com/encore/logeat/like/service/LikeService.java
+++ b/src/main/java/com/encore/logeat/like/service/LikeService.java
@@ -1,5 +1,7 @@
 package com.encore.logeat.like.service;
 
+import static com.encore.logeat.common.redis.CacheNames.POST;
+
 import com.encore.logeat.common.dto.ResponseDto;
 import com.encore.logeat.like.Repository.LikeRepository;
 import com.encore.logeat.like.domain.Like;
@@ -8,6 +10,7 @@ import com.encore.logeat.post.repository.PostRepository;
 import com.encore.logeat.user.domain.User;
 import com.encore.logeat.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -33,6 +36,7 @@ public class LikeService {
 
     @Transactional
     @PreAuthorize("hasAuthority('USER')")
+    @CacheEvict(cacheNames = POST, key = "#id")
     public ResponseDto postLike(Long id) {
         Post post = postRepository.findById(id).orElseThrow(() -> new EntityNotFoundException("post not found"));
 

--- a/src/main/java/com/encore/logeat/post/Dto/ResponseDto/PostDetailResponseDto.java
+++ b/src/main/java/com/encore/logeat/post/Dto/ResponseDto/PostDetailResponseDto.java
@@ -1,37 +1,41 @@
-package com.encore.logeat.post.Dto.ResponseDto;
+package com.encore.logeat.post.dto.ResponseDto;
 
 import com.encore.logeat.post.domain.Post;
+import java.time.format.DateTimeFormatter;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.time.LocalDate;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class PostDetailResponseDto {
-    private Long id;
-    private String title;
-    private String contents;
-    private String userNickname;
-    private int likeCount;
-    private String category;
-    private String location;
-    private String postImage;
-    private LocalDate createdTime;
 
-    public static PostDetailResponseDto toPostDetailResponseDto(Post post){
-        PostDetailResponseDto.PostDetailResponseDtoBuilder builder = PostDetailResponseDto.builder();
-            builder.id(post.getId());
-            builder.title(post.getTitle());
-            builder.contents(post.getContents());
-            builder.userNickname(post.getUser().getNickname());
-            builder.likeCount(post.getLikeCount());
-            builder.category(post.getCategory());
-            builder.location(post.getLocation());
+	private Long id;
+	private String title;
+	private String contents;
+	private String userNickname;
+	private int likeCount;
+	private String category;
+	private String location;
+	private String postImage;
+	private String createdTime;
+
+	public static PostDetailResponseDto toPostDetailResponseDto(Post post) {
+		PostDetailResponseDto.PostDetailResponseDtoBuilder builder = PostDetailResponseDto.builder();
+		builder.id(post.getId());
+		builder.title(post.getTitle());
+		builder.contents(post.getContents());
+		builder.userNickname(post.getUser().getNickname());
+		builder.likeCount(post.getLikeCount());
+		builder.category(post.getCategory());
+		builder.location(post.getLocation());
 //            builder.postImage(post.getImagePath());
-            builder.createdTime(post.getCreatedTime().toLocalDate());
+		builder.createdTime(
+			post.getCreatedTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
 
-        return builder.build();
-    }
+		return builder.build();
+	}
 }

--- a/src/main/java/com/encore/logeat/post/Service/PostService.java
+++ b/src/main/java/com/encore/logeat/post/Service/PostService.java
@@ -1,16 +1,17 @@
 package com.encore.logeat.post.Service;
 
+import static com.encore.logeat.common.redis.CacheNames.POST;
+
 import com.encore.logeat.post.Dto.RequestDto.PostCreateRequestDto;
 import com.encore.logeat.post.Dto.RequestDto.PostSecretUpdateRequestDto;
 import com.encore.logeat.post.Dto.RequestDto.PostUpdateRequestDto;
-import com.encore.logeat.post.Dto.ResponseDto.PostDetailResponseDto;
+import com.encore.logeat.post.dto.ResponseDto.PostDetailResponseDto;
 import com.encore.logeat.post.Dto.ResponseDto.PostSearchResponseDto;
 import com.encore.logeat.post.domain.Post;
 import com.encore.logeat.post.repository.PostRepository;
 import com.encore.logeat.user.domain.User;
 import com.encore.logeat.user.repository.UserRepository;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.UrlResource;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -18,8 +19,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import javax.persistence.EntityNotFoundException;
-import javax.transaction.Transactional;
-import java.util.stream.Collectors;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
@@ -156,6 +156,7 @@ public class PostService {
         return post;
     }
 
+    @Cacheable(cacheNames = POST, key = "#id")
     public PostDetailResponseDto postDetail(Long id) {
         Post post = postRepository.findById(id).orElseThrow(()-> new EntityNotFoundException("not found post"));
         PostDetailResponseDto postDetailResponseDto = PostDetailResponseDto.toPostDetailResponseDto(post);

--- a/src/main/java/com/encore/logeat/post/Service/PostService.java
+++ b/src/main/java/com/encore/logeat/post/Service/PostService.java
@@ -1,7 +1,10 @@
 package com.encore.logeat.post.Service;
 
 import static com.encore.logeat.common.redis.CacheNames.POST;
+import static com.encore.logeat.common.redis.CacheNames.createPostCacheKey;
+import static com.encore.logeat.common.redis.CacheNames.createViewCountCacheKey;
 
+import com.encore.logeat.common.redis.RedisService;
 import com.encore.logeat.post.Dto.RequestDto.PostCreateRequestDto;
 import com.encore.logeat.post.Dto.RequestDto.PostSecretUpdateRequestDto;
 import com.encore.logeat.post.Dto.RequestDto.PostUpdateRequestDto;
@@ -11,9 +14,14 @@ import com.encore.logeat.post.domain.Post;
 import com.encore.logeat.post.repository.PostRepository;
 import com.encore.logeat.user.domain.User;
 import com.encore.logeat.user.repository.UserRepository;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -27,9 +35,14 @@ public class PostService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
 
-    public PostService(PostRepository postRepository, UserRepository userRepository) {
+    private final RedisService redisService;
+
+    @Autowired
+    public PostService(PostRepository postRepository, UserRepository userRepository,
+        RedisService redisService) {
         this.postRepository = postRepository;
         this.userRepository = userRepository;
+        this.redisService = redisService;
     }
 
     @PreAuthorize("hasAuthority('USER')")
@@ -158,8 +171,42 @@ public class PostService {
 
     @Cacheable(cacheNames = POST, key = "#id")
     public PostDetailResponseDto postDetail(Long id) {
-        Post post = postRepository.findById(id).orElseThrow(()-> new EntityNotFoundException("not found post"));
+        Post post = findById(id);
         PostDetailResponseDto postDetailResponseDto = PostDetailResponseDto.toPostDetailResponseDto(post);
         return postDetailResponseDto;
+    }
+
+    public void addViewCountCache(Long postId) {
+        String viewCntKey = createViewCountCacheKey(postId);
+        if (!redisService.getValues(viewCntKey).equals("false")) {
+            redisService.increment(viewCntKey);
+            return;
+        }
+
+        redisService.setValues(viewCntKey, String.valueOf(findById(postId).getViewCount() + 1),
+            Duration.ofMinutes(3));
+    }
+
+    @Scheduled(cron = "0 0/3 * * * ?")
+    public void applyViewCountToRDB() {
+        Set<String> viewCntKeys = redisService.keys("postViewCnt*");
+        if(Objects.requireNonNull(viewCntKeys).isEmpty()) return;
+
+        for (String viewCntKey : viewCntKeys) {
+            Long postId = extractPostIdFromKey(viewCntKey);
+            Integer viewCount = Integer.parseInt(redisService.getValues(viewCntKey));
+
+            postRepository.applyViewCntToRDB(postId, viewCount);
+            redisService.deleteValues(viewCntKey);
+            redisService.deleteValues(createPostCacheKey(postId));
+        }
+    }
+    private Long extractPostIdFromKey(String viewCntKey) {
+        return Long.parseLong(viewCntKey.split("::")[1]);
+    }
+
+    public Post findById(Long postId) {
+        return postRepository.findById(postId)
+            .orElseThrow(() -> new EntityNotFoundException("해당 글을 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/com/encore/logeat/post/controller/PostController.java
+++ b/src/main/java/com/encore/logeat/post/controller/PostController.java
@@ -80,6 +80,7 @@ public class PostController {
 
     @GetMapping("/post/{id}/detail")
     public ResponseEntity<PostDetailResponseDto> postIncludeTitleSearch(@PathVariable Long id) {
+        postService.addViewCountCache(id);
         PostDetailResponseDto postDetailResponseDto = postService.postDetail(id);
         return new ResponseEntity<>(postDetailResponseDto, HttpStatus.OK);
     }

--- a/src/main/java/com/encore/logeat/post/controller/PostController.java
+++ b/src/main/java/com/encore/logeat/post/controller/PostController.java
@@ -4,7 +4,7 @@ import com.encore.logeat.common.dto.ResponseDto;
 import com.encore.logeat.post.Dto.RequestDto.PostCreateRequestDto;
 import com.encore.logeat.post.Dto.RequestDto.PostSecretUpdateRequestDto;
 import com.encore.logeat.post.Dto.RequestDto.PostUpdateRequestDto;
-import com.encore.logeat.post.Dto.ResponseDto.PostDetailResponseDto;
+import com.encore.logeat.post.dto.ResponseDto.PostDetailResponseDto;
 import com.encore.logeat.post.Dto.ResponseDto.PostSearchResponseDto;
 import com.encore.logeat.post.Service.PostService;
 import com.encore.logeat.post.domain.Post;

--- a/src/main/java/com/encore/logeat/post/domain/Post.java
+++ b/src/main/java/com/encore/logeat/post/domain/Post.java
@@ -34,7 +34,8 @@ public class Post extends BaseTimeEntity {
 	private String imagePath;
 	private String location;
 	private String category;
-	private int viewCount;
+	@Builder.Default
+	private int viewCount = 0;
 	@Builder.Default
 	@Column(name = "secret_y_or_n")
 	private String secretYorN = "N"; // 공개 여부

--- a/src/main/java/com/encore/logeat/post/repository/PostRepository.java
+++ b/src/main/java/com/encore/logeat/post/repository/PostRepository.java
@@ -5,11 +5,13 @@ import com.encore.logeat.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
@@ -26,4 +28,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT p FROM Post p JOIN p.user u WHERE (p.user.id = :userId OR p.secretYorN = 'N' OR p.secretYorN IS NULL) AND u.nickname LIKE %:userNickname%")
     Page<Post> findByUserNickname(@Param("userId") Long userId, @Param("userNickname") String userNickname, Pageable pageable);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Post p SET p.viewCount = :viewCount WHERE p.id = :postId")
+	void applyViewCntToRDB(@Param(("postId")) Long postId, @Param("viewCount") Integer viewCount);
 }


### PR DESCRIPTION
1. `@EnableScheduling` 조회수 반영 메서드 스케쥴링을 위한 어노테이션 선언

2. 캐싱할 때의 Redis에 저장될 Key의 이름이 될 `CacheName` 클래스 선언
- `createCacheKey` 메서드를 이용해서 CacheName::id형태로 Redis에 저장됨

3. `RedisConfig`
- `@EnableCaching` 어노테이션을 통하여 캐싱 기능 활성화
- Redis를 통한 캐싱 작업을 위해 `RedisCacheManger`를 빈으로 등록하고 RedisConnectionFactory를 매개변수로 받아 Redis 서버에 
연결을 할 수 있도록 함.
- `RedisCacheConfiguration`은 Redis에 저장되는 Cache의 기본 설정하는데에 사용되는 것이며 `serializeKeysWith`을 통하여 캐시 Key의 직렬화 방식을 정의 하는데 `StringRedisSerializer`로 Key의 저장 방식을 문자열로 정의함
- 또 `serializeValuesWith`를 통하여 Value의 직렬화 방식을 정의하고 `GenericJackson2JsonRedisSerializer`을 사용하여 Value의 저장 형식을 JSON으로 정의 함
- `redisCacheConfigMap`을 정의하여 특정이름의 캐시에 대하여 각각 다른 TTL(Time To Live)을 설정할 수 있는데 POST의 이름의 캐시의 경우 3분, USER_PROFILE의 경우 하루로 TTL 설정

4. `RedisService`
-  `increment` : Post 조회 시 이미 캐싱되어있는 조회수의 경우에 value에 1을 추가하는 메서드
-  `keys` : 조회수 반영을 하는 스케쥴이 실행 될때에 캐싱되어 있는 모든 키를 가져오기 위한 메서드

5. `LikeService`
- Like가 추가되거나 삭제될때에 `@CacheEvict(cacheNames = POST, key = "#id")`를 통하여 이미 저장되어 있는 글의 상세정보 캐시 삭제

6. PostDetailResponseDto
- 이미 저장된 글을 조회하는 경우 Redis에 저장된 캐시정보를 불러오게 되는데 이때의 경우 직렬화하는 과정에서 매개변수가 없는 기본 생성자가 필요하여 `@NoArgsConstructor @AllArgsConstructor`과 같은 어노테이션 적용 및 Dto의 날짜 형식 수정
7. `PostService `
- 공통으로 사용되는 `FindById` 메서드 정의
- `@Cacheable(cacheNames = POST, key = "#id")`를 통하여 글의 상세보기를 할 때 캐싱되도록 함.
- `addViewCountCache`: 이미 캐싱되어 있는 글 조회수의 Value를 1 올리고, 캐싱 되어 있지 않은 경우에는 조회수 캐싱용 Key와 Value설정후 저장
- `applyViewCountToRDB` : `@Scheduled(cron = "0 0/3 * * * ?")`을 통하여 서버시간 3분 마다 메서드가 실행되고
`postViewCnt*`이름을 가진 조회수 캐시들을 전부 가져와 `applyViewCntToRDB`메서드를 통하여 조회수를 업데이트한다.