### PR TITLE
[feat] 주간, 월간 좋아요 상위 리스트 구현

### DIFF
--- a/src/main/java/com/encore/logeat/like/service/LikeService.java
+++ b/src/main/java/com/encore/logeat/like/service/LikeService.java
@@ -3,7 +3,10 @@ package com.encore.logeat.like.service;
 import com.encore.logeat.common.dto.ResponseDto;
 import com.encore.logeat.like.Repository.LikeRepository;
 import com.encore.logeat.like.domain.Like;
+import com.encore.logeat.post.Dto.ResponseDto.PostLikeWeekResponseDto;
 import com.encore.logeat.post.domain.Post;
+import com.encore.logeat.post.domain.PostLikeReport;
+import com.encore.logeat.post.repository.PostLikeReportRepository;
 import com.encore.logeat.post.repository.PostRepository;
 import com.encore.logeat.user.domain.User;
 import com.encore.logeat.user.repository.UserRepository;
@@ -23,12 +26,14 @@ public class LikeService {
     private final LikeRepository likeRepository;
     private final UserRepository userRepository;
     private final PostRepository postRepository;
+    private final PostLikeReportRepository postLikeReportRepository;
 
     @Autowired
-    public LikeService(LikeRepository likeRepository, UserRepository userRepository, PostRepository postRepository) {
+    public LikeService(LikeRepository likeRepository, UserRepository userRepository, PostRepository postRepository, PostLikeReportRepository postLikeReportRepository) {
         this.likeRepository = likeRepository;
         this.userRepository = userRepository;
         this.postRepository = postRepository;
+        this.postLikeReportRepository = postLikeReportRepository;
     }
 
     @Transactional
@@ -56,6 +61,7 @@ public class LikeService {
                     .result(HttpStatus.OK)
                     .build();
             post.addLikeCount();
+            postLikeReportRepository.save(new PostLikeReport(post, post.getUser()));
 
         } else {
             Like like = likeList.get(0);
@@ -66,6 +72,7 @@ public class LikeService {
                     .result(HttpStatus.OK)
                     .build();
             post.reduceLikeCount();
+            postLikeReportRepository.delete(new PostLikeReport(post, post.getUser()));
         }
         return responseDto;
     }

--- a/src/main/java/com/encore/logeat/post/Dto/ResponseDto/PostLikeMonthResponseDto.java
+++ b/src/main/java/com/encore/logeat/post/Dto/ResponseDto/PostLikeMonthResponseDto.java
@@ -1,0 +1,17 @@
+package com.encore.logeat.post.Dto.ResponseDto;
+
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+
+@Getter
+@Builder
+public class PostLikeMonthResponseDto {
+    private Long postId;
+    private String title;
+    private String category; // List로 변경하기
+    private MultipartFile postImage;
+}

--- a/src/main/java/com/encore/logeat/post/Dto/ResponseDto/PostLikeWeekResponseDto.java
+++ b/src/main/java/com/encore/logeat/post/Dto/ResponseDto/PostLikeWeekResponseDto.java
@@ -1,0 +1,14 @@
+package com.encore.logeat.post.Dto.ResponseDto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Builder
+public class PostLikeWeekResponseDto {
+    private Long postId;
+    private String title;
+    private String category; // List로 변경하기
+    private MultipartFile postImage;
+}

--- a/src/main/java/com/encore/logeat/post/Service/PostService.java
+++ b/src/main/java/com/encore/logeat/post/Service/PostService.java
@@ -4,14 +4,20 @@ import com.encore.logeat.post.Dto.RequestDto.PostCreateRequestDto;
 import com.encore.logeat.post.Dto.RequestDto.PostSecretUpdateRequestDto;
 import com.encore.logeat.post.Dto.RequestDto.PostUpdateRequestDto;
 import com.encore.logeat.post.Dto.ResponseDto.PostDetailResponseDto;
+import com.encore.logeat.post.Dto.ResponseDto.PostLikeMonthResponseDto;
+import com.encore.logeat.post.Dto.ResponseDto.PostLikeWeekResponseDto;
 import com.encore.logeat.post.Dto.ResponseDto.PostSearchResponseDto;
 import com.encore.logeat.post.domain.Post;
+import com.encore.logeat.post.domain.PostLikeReport;
+import com.encore.logeat.post.repository.PostLikeReportRepository;
 import com.encore.logeat.post.repository.PostRepository;
 import com.encore.logeat.user.domain.User;
 import com.encore.logeat.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -19,16 +25,21 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import javax.persistence.EntityNotFoundException;
 import javax.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 @Transactional
 public class PostService {
     private final PostRepository postRepository;
+    private final PostLikeReportRepository postLikeReportRepository;
     private final UserRepository userRepository;
 
-    public PostService(PostRepository postRepository, UserRepository userRepository) {
+    @Autowired
+    public PostService(PostRepository postRepository, PostLikeReportRepository postLikeReportRepository, UserRepository userRepository) {
         this.postRepository = postRepository;
+        this.postLikeReportRepository = postLikeReportRepository;
         this.userRepository = userRepository;
     }
 
@@ -161,4 +172,44 @@ public class PostService {
         PostDetailResponseDto postDetailResponseDto = PostDetailResponseDto.toPostDetailResponseDto(post);
         return postDetailResponseDto;
     }
+
+
+    public List<PostLikeWeekResponseDto> postLikeWeekResponse() {
+        PageRequest pageRequest = PageRequest.of(0, 3);
+        LocalDateTime end = LocalDateTime.now().plusDays(1);
+        LocalDateTime start = end.minusDays(7);
+
+        return postLikeReportRepository.findPostLikeReportBy(start, end, pageRequest)
+                .stream()
+                .map(result -> PostLikeWeekResponseDto.builder()
+                        .postId(result.getPost().getId())
+                        .title(result.getPost().getTitle())
+                        .category(result.getPost().getCategory())
+                        .postImage(null)
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+
+    public List<PostLikeMonthResponseDto> postLikeMonthResponse() {
+        PageRequest pageRequest = PageRequest.of(0, 3);
+        LocalDateTime end = LocalDateTime.now().plusDays(1);
+        LocalDateTime start = end.minusMonths(1);
+
+        return postLikeReportRepository.findPostLikeReportBy(start, end, pageRequest)
+                .stream()
+                .map(result -> PostLikeMonthResponseDto.builder()
+                        .postId(result.getPost().getId())
+                        .title(result.getPost().getTitle())
+                        .category(result.getPost().getCategory())
+                        .postImage(null)
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+
+
+
+
+
 }

--- a/src/main/java/com/encore/logeat/post/controller/PostController.java
+++ b/src/main/java/com/encore/logeat/post/controller/PostController.java
@@ -12,9 +12,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.concurrent.TimeUnit;
 
 @RestController
 public class PostController {
@@ -82,6 +85,24 @@ public class PostController {
     public ResponseEntity<PostDetailResponseDto> postIncludeTitleSearch(@PathVariable Long id) {
         PostDetailResponseDto postDetailResponseDto = postService.postDetail(id);
         return new ResponseEntity<>(postDetailResponseDto, HttpStatus.OK);
+    }
+
+
+    @GetMapping("/post/like/weeks")
+    public ResponseEntity<?> postLikeWeeks() {
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .cacheControl(CacheControl.maxAge(30, TimeUnit.MINUTES))
+                .body(postService.postLikeWeekResponse());
+    }
+
+
+    @GetMapping("/post/like/month")
+    public ResponseEntity<?> postLikeMonth() {
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .cacheControl(CacheControl.maxAge(30, TimeUnit.MINUTES))
+                .body(postService.postLikeMonthResponse());
     }
 
 }

--- a/src/main/java/com/encore/logeat/post/domain/PostLikeReport.java
+++ b/src/main/java/com/encore/logeat/post/domain/PostLikeReport.java
@@ -26,11 +26,11 @@ public class PostLikeReport {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/com/encore/logeat/post/domain/PostLikeReport.java
+++ b/src/main/java/com/encore/logeat/post/domain/PostLikeReport.java
@@ -1,0 +1,39 @@
+package com.encore.logeat.post.domain;
+
+import com.encore.logeat.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+public class PostLikeReport {
+
+    protected PostLikeReport() {
+    }
+
+    public PostLikeReport(Post post, User user) {
+        this.post = post;
+        this.user = user;
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @CreationTimestamp
+    private LocalDateTime likeCreatedTime;
+}

--- a/src/main/java/com/encore/logeat/post/repository/PostLikeReportRepository.java
+++ b/src/main/java/com/encore/logeat/post/repository/PostLikeReportRepository.java
@@ -1,0 +1,33 @@
+package com.encore.logeat.post.repository;
+
+
+import com.encore.logeat.post.domain.PostLikeReport;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface PostLikeReportRepository extends JpaRepository<PostLikeReport, Long> {
+
+//    @Query("SELECT p.post, sum(p.likeCreatedTime) as count " +
+//            "FROM PostLikeReport p " +
+//            "WHERE p.likeCreatedTime between ?1 AND ?2 " +
+//            "GROUP BY p.post ")
+//    Page<PostLikeReport> findByPostLikeReport(LocalDateTime start, LocalDateTime endTime, Pageable pageable);
+
+    @Query("SELECT p " +
+            "FROM PostLikeReport p " +
+            "WHERE p.likeCreatedTime BETWEEN :startDate AND :endDate " +
+            "GROUP BY p.post " +
+            "ORDER BY COUNT(p.likeCreatedTime) DESC ")
+    Page<PostLikeReport> findPostLikeReportBy(@Param("startDate") LocalDateTime startDate,
+                                              @Param("endDate") LocalDateTime endDate, Pageable pageable);
+
+}

--- a/src/test/java/com/encore/logeat/junstin/MonthPostReadTest.java
+++ b/src/test/java/com/encore/logeat/junstin/MonthPostReadTest.java
@@ -1,0 +1,126 @@
+package com.encore.logeat.junstin;
+
+import com.encore.logeat.post.Dto.RequestDto.PostCreateRequestDto;
+import com.encore.logeat.post.Service.PostService;
+import com.encore.logeat.post.domain.Post;
+import com.encore.logeat.post.domain.PostLikeReport;
+import com.encore.logeat.post.repository.PostLikeReportRepository;
+import com.encore.logeat.post.repository.PostRepository;
+import com.encore.logeat.user.domain.Role;
+import com.encore.logeat.user.domain.User;
+import com.encore.logeat.user.repository.UserRepository;
+import com.encore.logeat.user.service.UserService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.parameters.P;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@SpringBootTest
+public class MonthPostReadTest {
+
+
+    private PostRepository postRepository;
+    private PostLikeReportRepository postLikeReportRepository;
+    private UserRepository userRepository;
+
+    @Autowired
+    public MonthPostReadTest(PostRepository postRepository, PostLikeReportRepository postLikeReportRepository, UserRepository userRepository) {
+        this.postRepository = postRepository;
+        this.postLikeReportRepository = postLikeReportRepository;
+        this.userRepository = userRepository;
+    }
+
+
+    @Test
+    @Transactional
+    public void 좋아요월간_주간_테스트() {
+
+        //PageRequest pageRequest = PageRequest.of(0, 5);
+        PageRequest pageRequest = PageRequest.of(0, 3);
+        LocalDateTime end = LocalDateTime.now().plusDays(1);
+        LocalDateTime start = end.minusDays(7);
+        //LocalDateTime start = end.minusMonths(1);
+
+        Page<PostLikeReport> id = postLikeReportRepository.findPostLikeReportBy(start, end, pageRequest);
+        List<PostLikeReport> list = id.toList();
+        int a =1;
+
+        Assertions.assertThat(3).isEqualTo(list.size());
+        //Assertions.assertThat(5).isEqualTo(list.size());
+    }
+
+
+    @Test
+    public void 월간테스트() {
+
+//        List<User> tempUser = List.of(
+//                User.builder().email("kim@gmail.com").nickname("김민재").password("12345").introduce("자기소개-김민재").role(Role.USER).build(),
+//                User.builder().email("son@gmail.com").nickname("손흥민").password("12345").introduce("자기소개-손흥민").role(Role.USER).build(),
+//                User.builder().email("park@gmail.com").nickname("박주영").password("12345").introduce("자기소개-박주영").role(Role.USER).build(),
+//                User.builder().email("lee@gmail.com").nickname("이청용").password("12345").introduce("자기소개-이청용").role(Role.USER).build()
+//        );
+//        userRepository.saveAll(tempUser);
+//
+//
+//        User parkUser = User.builder().email("jisung@gmail.com").nickname("박지성").password("12345").introduce("자기소개-박지성").role(Role.USER).build();
+//        userRepository.save(parkUser);
+//
+//        List<User> all = userRepository.findAll();
+//
+//        Assertions.assertThat(4).isEqualTo(all.size());
+
+
+//        List<Post> tempPost = List.of(
+//                Post.builder().title("포스트1번 제목").contents("포스트1번 내용").category("포스트1번 카테고리").location("포스트1번 location").user(userList.get(0)).build(),
+//                Post.builder().title("포스트2번 제목").contents("포스트2번 내용").category("포스트2번 카테고리").location("포스트2번 location").user(userList.get(1)).build(),
+//                Post.builder().title("포스트3번 제목").contents("포스트3번 내용").category("포스트3번 카테고리").location("포스트3번 location").user(userList.get(2)).build(),
+//                Post.builder().title("포스트4번 제목").contents("포스트4번 내용").category("포스트4번 카테고리").location("포스트4번 location").user(userList.get(3)).build(),
+//                Post.builder().title("포스트5번 제목").contents("포스트5번 내용").category("포스트5번 카테고리").location("포스트5번 location").user(userList.get(3)).build(),
+//                Post.builder().title("포스트6번 제목").contents("포스트6번 내용").category("포스트6번 카테고리").location("포스트6번 location").user(userList.get(2)).build(),
+//                Post.builder().title("포스트7번 제목").contents("포스트7번 내용").category("포스트7번 카테고리").location("포스트7번 location").user(userList.get(1)).build()
+//        );
+//        List<Post> postList = postRepository.saveAll(tempPost);
+//
+//        postList.get(0).addLikeCount();
+//        postList.get(0).addLikeCount();
+//        PostLikeReport postLikeReport1 = new PostLikeReport(postList.get(0));
+//        postLikeReportRepository.save(postLikeReport1);
+//
+//        postList.get(1).addLikeCount();
+//        PostLikeReport postLikeReport2 = new PostLikeReport(postList.get(1));
+//        postLikeReportRepository.save(postLikeReport2);
+//
+//        postList.get(2).addLikeCount();
+//        postList.get(2).addLikeCount();
+//        PostLikeReport postLikeReport3 = new PostLikeReport(postList.get(2));
+//        postLikeReportRepository.save(postLikeReport3);
+//
+//        postList.get(3).addLikeCount();
+//        postList.get(3).addLikeCount();
+//        postList.get(3).addLikeCount();
+//        PostLikeReport postLikeReport4 = new PostLikeReport(postList.get(3));
+//        postLikeReportRepository.save(postLikeReport4);
+//
+//        postList.get(4).addLikeCount();
+//        PostLikeReport postLikeReport5 = new PostLikeReport(postList.get(4));
+//        postLikeReportRepository.save(postLikeReport5);
+//
+//        postList.get(5).addLikeCount();
+//        postList.get(5).addLikeCount();
+//        PostLikeReport postLikeReport6 = new PostLikeReport(postList.get(5));
+//        postLikeReportRepository.save(postLikeReport6);
+
+    }
+
+
+}

--- a/src/test/java/com/encore/logeat/junstin/UpdatedPasswordTest.java
+++ b/src/test/java/com/encore/logeat/junstin/UpdatedPasswordTest.java
@@ -50,7 +50,7 @@ public class UpdatedPasswordTest {
         String changePwd = passwordEncoder.encode("5555");
 
         if(b) {
-            findUser.updatedPassword(changePwd);
+            findUser.userUpdatedPassword(changePwd);
         }
 
         Assertions.assertThat(passwordEncoder.matches("5555", findUser.getPassword())).isEqualTo(true);


### PR DESCRIPTION
- 게시글의 좋아요 시간을 찍기위한 PostLikeReport 테이블 생성
- 좋아요를 눌렀을 때 PostLikeReport row 추가
- 좋아요를 취소할 떄 PostLikeReport row 삭제
- 주간, 월간 좋아요 DAO 통합 -> 시간으로 가져오기
- 주간, 월간 좋아요 Controller 생성
- 좋아요 서비스 계층에 누른 시간 추가