### PR TITLE
[feat]글 작성시 팔로워들에게 알림 기능 구현

### DIFF
--- a/src/main/java/com/encore/logeat/notification/controller/NotificationController.java
+++ b/src/main/java/com/encore/logeat/notification/controller/NotificationController.java
@@ -1,0 +1,26 @@
+package com.encore.logeat.notification.controller;
+
+import com.encore.logeat.common.dto.ResponseDto;
+import com.encore.logeat.notification.service.NotificationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class NotificationController {
+
+	private final NotificationService notificationService;
+
+	@Autowired
+	public NotificationController(NotificationService notificationService) {
+		this.notificationService = notificationService;
+	}
+
+	@GetMapping("/user/notifications")
+	public ResponseEntity<ResponseDto> myAllNoti() {
+		ResponseDto responseDto = notificationService.getAllMyNoti();
+		return new ResponseEntity<>(responseDto, HttpStatus.OK);
+	}
+}

--- a/src/main/java/com/encore/logeat/notification/domain/Notification.java
+++ b/src/main/java/com/encore/logeat/notification/domain/Notification.java
@@ -1,0 +1,41 @@
+package com.encore.logeat.notification.domain;
+
+import com.encore.logeat.common.entity.BaseTimeEntity;
+import com.encore.logeat.user.domain.User;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class Notification extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "sender_id")
+	private User sender;
+
+	private String url_path;
+
+	@Enumerated(EnumType.STRING)
+	private NotificationType notificationType;
+
+	@Builder.Default
+	private String isDelete = "N";
+}

--- a/src/main/java/com/encore/logeat/notification/domain/Notification.java
+++ b/src/main/java/com/encore/logeat/notification/domain/Notification.java
@@ -27,9 +27,11 @@ public class Notification extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	private String senderName;
+
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "sender_id")
-	private User sender;
+	@JoinColumn(name = "provider_id")
+	private User provider;
 
 	private String url_path;
 

--- a/src/main/java/com/encore/logeat/notification/domain/NotificationType.java
+++ b/src/main/java/com/encore/logeat/notification/domain/NotificationType.java
@@ -1,0 +1,14 @@
+package com.encore.logeat.notification.domain;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum NotificationType {
+	POST("새로운 기록이 작성되었습니다!"), FOLLOW("새로운 팔로워가 있어요!");
+
+	private final String message;
+
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/main/java/com/encore/logeat/notification/dto/request/NotificationCreateDto.java
+++ b/src/main/java/com/encore/logeat/notification/dto/request/NotificationCreateDto.java
@@ -1,0 +1,17 @@
+package com.encore.logeat.notification.dto.request;
+
+
+import com.encore.logeat.notification.domain.NotificationType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class NotificationCreateDto {
+	private Long sender_id;
+	private String url_path;
+	private NotificationType notificationType;
+
+}

--- a/src/main/java/com/encore/logeat/notification/dto/response/NotificationListResponseDto.java
+++ b/src/main/java/com/encore/logeat/notification/dto/response/NotificationListResponseDto.java
@@ -1,0 +1,21 @@
+package com.encore.logeat.notification.dto.response;
+
+import com.encore.logeat.notification.domain.Notification;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class NotificationListResponseDto {
+
+	private String senderName;
+	private String url_path;
+	private String message;
+
+	public static NotificationListResponseDto toDto(Notification notification) {
+		return NotificationListResponseDto.builder()
+			.senderName(notification.getSenderName())
+			.url_path(notification.getUrl_path())
+			.message(notification.getNotificationType().getMessage()).build();
+	}
+}

--- a/src/main/java/com/encore/logeat/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/encore/logeat/notification/repository/NotificationRepository.java
@@ -1,0 +1,8 @@
+package com.encore.logeat.notification.repository;
+
+import com.encore.logeat.notification.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/src/main/java/com/encore/logeat/notification/service/NotificationService.java
+++ b/src/main/java/com/encore/logeat/notification/service/NotificationService.java
@@ -1,0 +1,70 @@
+package com.encore.logeat.notification.service;
+
+import com.encore.logeat.common.dto.ResponseDto;
+import com.encore.logeat.follow.domain.Follow;
+import com.encore.logeat.notification.domain.Notification;
+import com.encore.logeat.notification.dto.request.NotificationCreateDto;
+import com.encore.logeat.notification.dto.response.NotificationListResponseDto;
+import com.encore.logeat.notification.repository.NotificationRepository;
+import com.encore.logeat.user.domain.User;
+import com.encore.logeat.user.repository.UserRepository;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import javax.persistence.EntityNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class NotificationService {
+
+	private final NotificationRepository notificationRepository;
+	private final UserRepository userRepository;
+
+	@Autowired
+	public NotificationService(NotificationRepository notificationRepository,
+		UserRepository userRepository) {
+		this.notificationRepository = notificationRepository;
+		this.userRepository = userRepository;
+	}
+
+	public void createNotification(NotificationCreateDto notificationCreateDto) {
+		User sender = userRepository.findById(notificationCreateDto.getSender_id())
+			.orElseThrow(() -> new EntityNotFoundException("해당 유저가 존재하지 않습니다."));
+		List<User> users = sender.getFollowerList().stream().map(Follow::getFollower)
+			.collect(Collectors.toList());
+		for (User user : users) {
+			Notification notification = Notification.builder()
+				.notificationType(notificationCreateDto.getNotificationType())
+				.senderName(sender.getNickname())
+				.url_path(notificationCreateDto.getUrl_path())
+				.provider(user)
+				.build();
+			notificationRepository.save(notification);
+		}
+
+	}
+
+	@PreAuthorize("hasAuthority('USER')")
+	public ResponseDto getAllMyNoti() {
+		String name = SecurityContextHolder.getContext().getAuthentication().getName();
+		String[] split = name.split(":");
+		long userId = Long.parseLong(split[0]);
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new IllegalArgumentException("예상치 못한 에러가 발생하였습니다."));
+		Map<Long, Object> notifications = new HashMap<>();
+		for (Notification notification : user.getNotifications()) {
+			notifications.put(notification.getId(),
+				NotificationListResponseDto.toDto(notification));
+		}
+		return new ResponseDto(HttpStatus.OK, "All My Notifications", notifications);
+	}
+}

--- a/src/main/java/com/encore/logeat/notification/service/NotificationService.java
+++ b/src/main/java/com/encore/logeat/notification/service/NotificationService.java
@@ -8,6 +8,7 @@ import com.encore.logeat.notification.dto.response.NotificationListResponseDto;
 import com.encore.logeat.notification.repository.NotificationRepository;
 import com.encore.logeat.user.domain.User;
 import com.encore.logeat.user.repository.UserRepository;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,7 @@ public class NotificationService {
 			.orElseThrow(() -> new EntityNotFoundException("해당 유저가 존재하지 않습니다."));
 		List<User> users = sender.getFollowerList().stream().map(Follow::getFollower)
 			.collect(Collectors.toList());
+		List<Notification> notifications = new ArrayList<>();
 		for (User user : users) {
 			Notification notification = Notification.builder()
 				.notificationType(notificationCreateDto.getNotificationType())
@@ -47,9 +49,9 @@ public class NotificationService {
 				.url_path(notificationCreateDto.getUrl_path())
 				.provider(user)
 				.build();
-			notificationRepository.save(notification);
+			notifications.add(notification);
 		}
-
+		notificationRepository.saveAll(notifications);
 	}
 
 	@PreAuthorize("hasAuthority('USER')")

--- a/src/main/java/com/encore/logeat/user/domain/User.java
+++ b/src/main/java/com/encore/logeat/user/domain/User.java
@@ -48,7 +48,7 @@ public class User extends BaseTimeEntity {
 	@OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
 	private List<Post> postList;
 
-	@OneToMany(mappedBy = "sender", fetch = FetchType.LAZY)
+	@OneToMany(mappedBy = "provider", fetch = FetchType.LAZY)
 	private List<Notification> notifications;
 
 	@OneToMany(mappedBy = "following", fetch = FetchType.LAZY)

--- a/src/main/java/com/encore/logeat/user/domain/User.java
+++ b/src/main/java/com/encore/logeat/user/domain/User.java
@@ -4,6 +4,7 @@ package com.encore.logeat.user.domain;
 
 import com.encore.logeat.common.entity.BaseTimeEntity;
 import com.encore.logeat.follow.domain.Follow;
+import com.encore.logeat.notification.domain.Notification;
 import com.encore.logeat.post.domain.Post;
 import java.util.List;
 import javax.persistence.Column;
@@ -47,7 +48,10 @@ public class User extends BaseTimeEntity {
 	@OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
 	private List<Post> postList;
 
-	@OneToMany(mappedBy = "following",fetch = FetchType.LAZY)
+	@OneToMany(mappedBy = "sender", fetch = FetchType.LAZY)
+	private List<Notification> notifications;
+
+	@OneToMany(mappedBy = "following", fetch = FetchType.LAZY)
 	private List<Follow> followerList; // 유저를 팔로우
 
 	@OneToMany(mappedBy = "follower",fetch = FetchType.LAZY)


### PR DESCRIPTION
1. `Notification` 테이블 생성
- `Notification`테이블은 보낸사람의 닉네임, 받는 사람, url, 알림의 타입, 삭제 여부로 구성이 된다.
2. `User`테이블의 연관 관계
- `User`는 `List<Notification>`의 형식으로 알림 리스트를 가지게 된다.
3. 글 작성 시 `Notification` 생성 순서
- 글이 작성될 경우 `NotificationCreateDto`를 통하여 글 작성자의 id, 글 상세보기의 url, 알림의 타입을 지정하여 `notificationService.createNotification`를 통하여 알림을 생성한다.
- `createNotification`은 Dto에 저장된 id를 통하여 보낸 User를 가져오게 되고 User의 팔로워 리스트별로 `Notification`을 생성한다.
4. User의 알림 조회 기능 구현