### PR TITLE
[fix] CORS 설정

### DIFF
--- a/src/main/java/com/encore/logeat/common/security/SecurityConfig.java
+++ b/src/main/java/com/encore/logeat/common/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.encore.logeat.common.security;
 
 import com.encore.logeat.common.jwt.JwtAuthenticationFilter;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,6 +13,7 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
 
 @EnableWebSecurity
 @EnableMethodSecurity(prePostEnabled = true)
@@ -28,8 +30,14 @@ public class SecurityConfig {
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
 		httpSecurity.csrf(csrf -> csrf.disable())
-			.cors(cors -> cors.disable())
-			.httpBasic(basic -> basic.disable())
+			.cors().configurationSource(request -> {
+				CorsConfiguration corsConfiguration = new CorsConfiguration();
+				corsConfiguration.setAllowedOrigins(List.of("http://localhost:8082"));
+				corsConfiguration.setAllowedMethods(List.of("GET","POST", "PUT", "DELETE", "OPTIONS"));
+				corsConfiguration.setAllowedHeaders(List.of("*"));
+				return corsConfiguration;
+			});
+			httpSecurity.httpBasic(basic -> basic.disable())
 			.authorizeHttpRequests(req -> req
 				.antMatchers()
 				.permitAll()


### PR DESCRIPTION
1. `SecurityFilterChain`
- disable()이었던 CORS설정을 변경하였습니다.
- localhost:8082의 도메인을 가진 주소의 요청을 허용합니다.
- 모든 http메서드의 요청을 허용합니다.
- 모든 헤더 형식을 허용합니다.